### PR TITLE
Update blogs for home page and product page to show only 5

### DIFF
--- a/widgets/beesblogrecentposts/beesblogrecentposts.php
+++ b/widgets/beesblogrecentposts/beesblogrecentposts.php
@@ -98,7 +98,7 @@ class BeesBlogRecentPosts extends Module
             return '';
         }
 
-        $recentPosts = BeesBlogPost::getPosts($this->context->language->id, 0, 5);
+        $recentPosts = BeesBlogPost::getPosts($this->context->language->id, 0, 4);
         if (is_array($recentPosts)) {
             foreach ($recentPosts as &$recentPost) {
                 $recentPost->link = BeesBlog::GetBeesBlogLink('beesblog_post', ['blog_rewrite' => $recentPost->link_rewrite]);
@@ -124,7 +124,7 @@ class BeesBlogRecentPosts extends Module
             return '';
         }
 
-        $recentPosts = BeesBlogPost::getPosts($this->context->language->id, 0, 5);
+        $recentPosts = BeesBlogPost::getPosts($this->context->language->id, 0, 4);
         if (is_array($recentPosts)) {
             foreach ($recentPosts as &$recentPost) {
                 $recentPost->link = BeesBlog::GetBeesBlogLink('beesblog_post', ['blog_rewrite' => $recentPost->link_rewrite]);


### PR DESCRIPTION
This change allows only 4 posts on the home page and product page as the default community template and the actual template for bootstrap have been configured for 4 columns not 5. Sidepanel have been left at 5