### PR TITLE
Change IMG paths to absolute

### DIFF
--- a/views/templates/front/category.tpl
+++ b/views/templates/front/category.tpl
@@ -31,7 +31,7 @@
 {else}
 	{if isset($showCategoryImage) && $showCategoryImage && isset($categoryImageUrl) && $categoryImageUrl}
 		<div>
-			<img class="img-responsive" alt="{$category->title|escape:'htmlall':'UTF-8'}" src="{$categoryImageUrl|escape:'htmlall':'UTF-8'}">
+			<img class="img-responsive" alt="{$category->title|escape:'htmlall':'UTF-8'}" src="{$link->$getMediaLink($categoryImageUrl)|escape:'htmlall':'UTF-8'}">
 			<em>{$category->description}</em>
 			<br />
 			<br />

--- a/views/templates/front/post.tpl
+++ b/views/templates/front/post.tpl
@@ -31,7 +31,7 @@
 			<h4 class="title_block">{$post->title|escape:'htmlall':'UTF-8'}</h4>
 			{assign var=imagePath value=Media::getMediaPath(BeesBlog::getPostImagePath($post->id))}
 			{if ($imagePath)}
-				<img class="img-responsive" alt="{$post->title|escape:'htmlall':'UTF-8'}" src="{$imagePath|escape:'htmlall':'UTF-8'}">
+				<img class="img-responsive" alt="{$post->title|escape:'htmlall':'UTF-8'}" src="{$link->getMediaLink($imagePath)|escape:'htmlall':'UTF-8'}">
 			{/if}
 		</div>
 		<div class="block">

--- a/views/templates/front/post.tpl
+++ b/views/templates/front/post.tpl
@@ -31,7 +31,7 @@
 			<h1 class="title_block">{$post->title|escape:'htmlall':'UTF-8'}</h1>
 			{assign var=imagePath value=Media::getMediaPath(BeesBlog::getPostImagePath($post->id))}
 			{if ($imagePath)}
-				<img class="img-responsive" alt="{$post->title|escape:'htmlall':'UTF-8'}" src="{$imagePath|escape:'htmlall':'UTF-8'}">
+				<img class="img-responsive" alt="{$post->title|escape:'htmlall':'UTF-8'}" src="{$link->getMediaLink($imagePath)|escape:'htmlall':'UTF-8'}">
 			{/if}
 		</div>
 		<div class="block">

--- a/views/templates/front/post_list_item.tpl
+++ b/views/templates/front/post_list_item.tpl
@@ -29,7 +29,7 @@
                 {if ($imagePath)}
                     <a title="{$post->title|escape:'htmlall':'UTF-8'}" href="{$postPath|escape:'htmlall':'UTF-8'}">
                         <img class="img-responsive" alt="{$post->title|escape:'htmlall':'UTF-8'}"
-                             src="{$imagePath|escape:'htmlall':'UTF-8'}">
+                             src="{$link->getMediaLink($imagePath)|escape:'htmlall':'UTF-8'}">
                     </a>
                 {/if}
                 <span class="clearfix">


### PR DESCRIPTION
Blog module templates use relative paths for images. This means, blog images won't be redirected to CDN media servers when enabled.

This change relative paths to absolute ones with CDN support.