### PR TITLE
Expose blog posts and categories through the core webservice API (v1.8.0)

### DIFF
--- a/beesblog.php
+++ b/beesblog.php
@@ -87,7 +87,7 @@ class BeesBlog extends Module
     {
         $this->name = 'beesblog';
         $this->tab = 'front_office_features';
-        $this->version = '1.7.0';
+        $this->version = '1.8.0';
         $this->author = 'thirty bees';
         $this->tb_min_version = '1.0.0';
         $this->tb_versions_compliancy = '> 1.0.0';
@@ -173,6 +173,7 @@ class BeesBlog extends Module
             $this->registerHook('GSitemapAppendUrls') &&
             $this->registerHook('actionRegisterShortcodes') &&
             $this->registerHook('actionRegisterShortcodeEntityTypes') &&
+            $this->registerHook('addWebserviceResources') &&
             $this->insertBlogHooks()
         );
     }
@@ -621,8 +622,31 @@ class BeesBlog extends Module
         ];
     }
 
+    /**
+     * Registers blog entities as webservice (API) resources
+     *
+     * @return array
+     */
+    public function hookAddWebserviceResources()
+    {
+        // shop associations are normally registered by the admin controllers;
+        // the webservice bypasses those, so register them here as well
+        Shop::addTableAssociation(BeesBlogCategory::TABLE, ['type' => 'shop']);
+        Shop::addTableAssociation(BeesBlogPost::TABLE, ['type' => 'shop']);
 
-        /**
+        return [
+            'bees_blog_posts'      => [
+                'description' => 'Bees Blog posts',
+                'class'       => BeesBlogPost::class,
+            ],
+            'bees_blog_categories' => [
+                'description' => 'Bees Blog categories',
+                'class'       => BeesBlogCategory::class,
+            ],
+        ];
+    }
+
+    /**
      * Get module configuration page
      *
      * @return string HTML

--- a/classes/BeesBlogCategory.php
+++ b/classes/BeesBlogCategory.php
@@ -27,6 +27,9 @@ use DbQuery;
 use ObjectModel;
 use PrestaShopDatabaseException;
 use PrestaShopException;
+use Tools;
+use Validate;
+use WebserviceRequest;
 
 if (!defined('_TB_VERSION_')) {
     exit;
@@ -59,10 +62,21 @@ class BeesBlogCategory extends ObjectModel
             'date_upd'          => ['type' => self::TYPE_DATE,                   'validate' => 'isString',      'required' => true,  'default' => '1970-01-01 00:00:00', 'db_type' => 'DATETIME'],
             'title'             => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isString',      'required' => true,                                      'db_type' => 'VARCHAR(255)'],
             'description'       => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isString',      'required' => false,                                     'db_type' => 'VARCHAR(512)'],
-            'link_rewrite'      => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isString',      'required' => true,                                      'db_type' => 'VARCHAR(256)'],
+            'link_rewrite'      => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isLinkRewrite', 'required' => true,                                      'db_type' => 'VARCHAR(256)', 'ws_modifier' => ['http_method' => WebserviceRequest::HTTP_POST, 'modifier' => 'modifierWsLinkRewrite']],
             'meta_title'        => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => false,                                     'db_type' => 'VARCHAR(128)'],
             'meta_description'  => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => false,                                     'db_type' => 'VARCHAR(255)'],
             'meta_keywords'     => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => false,                                     'db_type' => 'VARCHAR(255)'],
+        ],
+    ];
+
+    /**
+     * @var array Webservice parameters
+     */
+    protected $webserviceParameters = [
+        'objectNodeName'  => 'bees_blog_category',
+        'objectsNodeName' => 'bees_blog_categories',
+        'fields'          => [
+            'id_parent' => ['xlink_resource' => 'bees_blog_categories'],
         ],
     ];
 
@@ -386,5 +400,27 @@ class BeesBlogCategory extends ObjectModel
         $sql->where('sbcl.`'.static::PRIMARY.'` = \''.pSQL($id).'\'');
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+    }
+
+    /**
+     * Derives or sanitizes link_rewrite values on webservice creation, same
+     * pattern as Product::modifierWsLinkRewrite()
+     *
+     * @return bool
+     */
+    public function modifierWsLinkRewrite()
+    {
+        if (!is_array($this->link_rewrite)) {
+            $this->link_rewrite = [];
+        }
+        foreach ((array) $this->title as $idLang => $title) {
+            if (empty($this->link_rewrite[$idLang])) {
+                $this->link_rewrite[$idLang] = Tools::link_rewrite($title);
+            } elseif (!Validate::isLinkRewrite($this->link_rewrite[$idLang])) {
+                $this->link_rewrite[$idLang] = Tools::link_rewrite($this->link_rewrite[$idLang]);
+            }
+        }
+
+        return true;
     }
 }

--- a/classes/BeesBlogPost.php
+++ b/classes/BeesBlogPost.php
@@ -28,6 +28,9 @@ use DbQuery;
 use ObjectModel;
 use PrestaShopDatabaseException;
 use PrestaShopException;
+use Tools;
+use Validate;
+use WebserviceRequest;
 
 if (!defined('_TB_VERSION_')) {
     exit;
@@ -65,12 +68,24 @@ class BeesBlogPost extends ObjectModel
             'post_type'         => ['type' => self::TYPE_STRING,                 'validate' => 'isString',      'required' => true,                                      'db_type' => 'VARCHAR(45)',  'size' => 45],
             'viewed'            => ['type' => self::TYPE_INT,                    'validate' => 'isUnsignedInt', 'required' => true,  'default' => '0',                   'db_type' => 'INT(20) UNSIGNED'],
             'title'             => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isString',      'required' => true,                                      'db_type' => 'VARCHAR(255)'],
-            'content'           => ['type' => self::TYPE_HTML,   'lang' => true, 'validate' => 'isString',      'required' => false,                                     'db_type' => 'TEXT'],
-            'link_rewrite'      => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isString',      'required' => true,                                      'db_type' => 'VARCHAR(255)'],
+            'content'           => ['type' => self::TYPE_HTML,   'lang' => true, 'validate' => 'isCleanHtml',   'required' => false,                                     'db_type' => 'TEXT'],
+            'link_rewrite'      => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isLinkRewrite', 'required' => true,                                      'db_type' => 'VARCHAR(255)', 'ws_modifier' => ['http_method' => WebserviceRequest::HTTP_POST, 'modifier' => 'modifierWsLinkRewrite']],
             'meta_title'        => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => false,                                     'db_type' => 'VARCHAR(128)'],
             'meta_description'  => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => false,                                     'db_type' => 'VARCHAR(255)'],
             'meta_keywords'     => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => false,                                     'db_type' => 'VARCHAR(255)'],
-            'lang_active'       => ['type' => self::TYPE_BOOL,   'lang' => true, 'validate' => 'isBool', 'db_type' => 'TINYINT(1) UNSIGNED'],
+            'lang_active'       => ['type' => self::TYPE_BOOL,   'lang' => true, 'validate' => 'isBool', 'db_type' => 'TINYINT(1) UNSIGNED', 'ws_modifier' => ['http_method' => WebserviceRequest::HTTP_POST | WebserviceRequest::HTTP_PUT, 'modifier' => 'modifierWsLangActive']],
+        ],
+    ];
+
+    /**
+     * @var array Webservice parameters
+     */
+    protected $webserviceParameters = [
+        'objectNodeName'  => 'bees_blog_post',
+        'objectsNodeName' => 'bees_blog_posts',
+        'fields'          => [
+            'id_category' => ['xlink_resource' => 'bees_blog_categories'],
+            'id_employee' => ['xlink_resource' => 'employees'],
         ],
     ];
 
@@ -584,5 +599,50 @@ class BeesBlogPost extends ObjectModel
     public static function dropRelatedProductsTable()
     {
         return Db::getInstance()->execute('DROP TABLE IF EXISTS `'._DB_PREFIX_.'bees_blog_post_product`');
+    }
+
+    /**
+     * Derives or sanitizes link_rewrite values on webservice creation, same
+     * pattern as Product::modifierWsLinkRewrite()
+     *
+     * @return bool
+     */
+    public function modifierWsLinkRewrite()
+    {
+        if (!is_array($this->link_rewrite)) {
+            $this->link_rewrite = [];
+        }
+        foreach ((array) $this->title as $idLang => $title) {
+            if (empty($this->link_rewrite[$idLang])) {
+                $this->link_rewrite[$idLang] = Tools::link_rewrite($title);
+            } elseif (!Validate::isLinkRewrite($this->link_rewrite[$idLang])) {
+                $this->link_rewrite[$idLang] = Tools::link_rewrite($this->link_rewrite[$idLang]);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Defaults omitted lang_active values to enabled on webservice writes;
+     * the webservice assigns an empty string to omitted i18n fields, which
+     * would otherwise be stored as 0 and hide the post in the front office
+     * while the API reports success
+     *
+     * @return bool
+     */
+    public function modifierWsLangActive()
+    {
+        if (is_array($this->lang_active)) {
+            foreach ($this->lang_active as $idLang => $value) {
+                if ($value === '' || $value === null) {
+                    $this->lang_active[$idLang] = 1;
+                }
+            }
+        } elseif ($this->lang_active === '' || $this->lang_active === null) {
+            $this->lang_active = 1;
+        }
+
+        return true;
     }
 }

--- a/upgrade/upgrade-1.8.0.php
+++ b/upgrade/upgrade-1.8.0.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright (C) 2017-2026 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <modules@thirtybees.com>
+ * @copyright 2017-2026 thirty bees
+ * @license   Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_TB_VERSION_')) {
+    exit;
+}
+
+/**
+ * @return bool
+ * @throws PrestaShopDatabaseException
+ * @throws PrestaShopException
+ */
+function upgrade_module_1_8_0()
+{
+    $instance = Module::getInstanceByName('beesblog');
+    if (!$instance instanceof BeesBlog) {
+        throw new PrestaShopException('beesblog upgrade 1.8.0: could not load module instance');
+    }
+
+    // re-register all hooks, which adds the new addWebserviceResources hook
+    return $instance->registerHooks();
+}


### PR DESCRIPTION
﻿
## Why

Blog content is not reachable over the core webservice (`/api`), so headless frontends, sync tools and external editors cannot read or manage posts. With core support for the `addWebserviceResources` hook (see companion core PR), the module can register its entities as first-class API resources.

**Depends on**: thirtybees/thirtybees#2131. Without that core change this module version installs fine but the resources simply do not appear.

## What

- Register the `addWebserviceResources` hook and return two resources:
  - `bees_blog_posts` (`BeesBlogModule\BeesBlogPost`)
  - `bees_blog_categories` (`BeesBlogModule\BeesBlogCategory`)
- All fields, multilang values and validation come automatically from the ObjectModel `$definition`; explicit `$webserviceParameters` only set node names and xlink associations (`id_category` -> `bees_blog_categories`, `id_employee` -> `employees`, `id_parent` -> `bees_blog_categories`).
- The hook handler also registers the `Shop` table associations. These were only set up by the admin controllers, so webservice writes would otherwise skip the `_shop` tables (posts invisible in the front office) and listings would not be filtered by shop context.
- Version bump to 1.8.0 with an upgrade script that registers the new hook on existing installations (throws `PrestaShopException` when the module instance cannot be loaded, instead of failing silently).

## Security hardening (validation parity with core)

Because API keys are a new, weaker principal class than BO employees, field validation is tightened to match what core uses for the equivalent CMS fields:

- `content`: `isString` changed to `isCleanHtml`. Blocks script tags and event-handler attributes from being stored via the API (the front office renders post content unescaped). Iframe/embed handling keeps following the shop's `PS_ALLOW_HTML_IFRAME` setting, exactly like core CMS content, so existing video embeds keep working. Note: existing posts that contain script tags will now fail validation on their next save.
- `link_rewrite` (post and category): `isString` changed to `isLinkRewrite`, plus a `ws_modifier` on POST that derives the slug from the title or sanitizes an invalid one, same pattern as `Product::modifierWsLinkRewrite()`. Prevents slug-based XSS and route confusion.
- `lang_active`: new `ws_modifier` on POST and PUT that defaults omitted values to enabled. The webservice assigns an empty string to omitted i18n fields, which would otherwise be stored as 0 and hide the post in the front office while the API reports success.

## API contract notes

- POST requires every `required` field from the definition, including `date_add`, `date_upd`, `published`, `position`, `viewed` and `post_type`; the webservice derives requirements from the ObjectModel definition and does not auto-fill dates. Omissions return error 41 with the field name.
- PUT is full-replace, like every core webservice resource: fetch the object (or blank schema), modify, send the complete XML back. Omitted optional i18n fields are cleared.
- The `lang_active` default applies when the field is omitted entirely or a value is sent empty. A client that sends `lang_active` language nodes for a subset of the shop languages still gets 0 for the languages it left out (standard core behaviour for non-required i18n fields): enumerate all languages or omit the field.
- GET returns all posts, including inactive and future-dated ones; the webservice layer does not apply front-office visibility filters (same as core products). Treat a blog GET grant accordingly.
- `id_employee` is exposed (xlinked to the `employees` resource, which stays behind its own permission grant); it reveals which employee authored a post to any blog-GET consumer.
- On shops with a persistent cache backend (memcached/redis), flush the cache after upgrading so the new hook registration is picked up.

## Testing

1. Install core with the companion PR, enable the webservice (Advanced Parameters > Webservice) and create a key.
2. The permissions grid shows `bees_blog_posts` and `bees_blog_categories`; grant GET/POST/PUT/DELETE.
3. `GET /api/bees_blog_posts` and `GET /api/bees_blog_categories` list the entities; `?display=full` returns all fields incl. language nodes.
4. `POST /api/bees_blog_posts` with a full XML body creates a post that is visible in Back Office and front office (shop association row is written).
5. Blog images are not managed through the API (only the `image` filename field is exposed); uploads still go through the Back Office.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
